### PR TITLE
Enhance Tetris-like block game with pause and auto-save

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# gamexephinh
+# Block Blast
+
+A lightweight Tetris clone built with vanilla JavaScript. Pieces fall automatically on a 20x10 grid and can be moved or rotated with the keyboard. Clear full rows to score points. The game now supports pause/resume, simple sound effects and automatically saves/restores your game state using `localStorage`.
+
+Controls:
+- **Arrow Left/Right** – move piece
+- **Arrow Up** – rotate piece
+- **Arrow Down** – soft drop
+- **Space** – hard drop
+- **P** – pause/resume
+
+## Development
+Open `index.html` in a modern browser to play. The game tracks score, best score and current game state in `localStorage`.

--- a/css/game.css
+++ b/css/game.css
@@ -1,0 +1,31 @@
+.grid-container {
+    display: grid;
+    grid-template-columns: repeat(10, 30px);
+    grid-template-rows: repeat(20, 30px);
+    gap: 2px;
+    background: #ddd;
+    padding: 2px;
+}
+
+.grid-cell {
+    width: 30px;
+    height: 30px;
+    background: #fafafa;
+    border: 1px solid #ccc;
+}
+
+.next-block {
+    margin-left: 20px;
+}
+
+.block {
+    display: inline-grid;
+    gap: 2px;
+}
+
+.block-cell {
+    width: 30px;
+    height: 30px;
+    border-radius: 4px;
+    box-shadow: inset 0 0 2px rgba(0,0,0,0.3);
+}

--- a/css/main.css
+++ b/css/main.css
@@ -1,0 +1,43 @@
+body {
+    font-family: Arial, sans-serif;
+    background: #f5f5f5;
+    margin: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+}
+
+.game-container {
+    background: #fff;
+    padding: 10px;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.game-board {
+    display: flex;
+    align-items: flex-start;
+}
+
+.game-header, .game-controls {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.btn-restart, .btn-sound, .btn-pause {
+    padding: 8px 12px;
+    border: none;
+    background: #007bff;
+    color: #fff;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.btn-restart:hover, .btn-sound:hover, .btn-pause:hover {
+    background: #0056b3;
+}

--- a/css/responsive.css
+++ b/css/responsive.css
@@ -1,0 +1,22 @@
+@media (max-width: 768px) {
+    .grid-container {
+        grid-template-columns: repeat(10, 20px);
+        grid-template-rows: repeat(20, 20px);
+    }
+
+    .grid-cell,
+    .block-cell {
+        width: 20px;
+        height: 20px;
+    }
+
+    .game-board {
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .next-block {
+        margin-left: 0;
+        margin-top: 10px;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Block Blast</title>
+    <link rel="stylesheet" href="css/main.css">
+    <link rel="stylesheet" href="css/game.css">
+    <link rel="stylesheet" href="css/responsive.css">
+</head>
+<body>
+<div class="game-container">
+    <header class="game-header">
+        <div class="score">0</div>
+        <div class="high-score">Best: 0</div>
+    </header>
+
+    <main class="game-board">
+        <div class="grid-container"></div>
+        <div class="next-block"></div>
+    </main>
+
+    <footer class="game-controls">
+        <button class="btn-pause">Pause</button>
+        <button class="btn-restart">New Game</button>
+        <button class="btn-sound">🔊</button>
+    </footer>
+</div>
+
+<script type="module" src="js/game.js"></script>
+</body>
+</html>

--- a/js/audio.js
+++ b/js/audio.js
@@ -1,0 +1,33 @@
+export class Sound {
+    constructor() {
+        this.enabled = true;
+        this.ctx = null;
+    }
+
+    toggle() {
+        this.enabled = !this.enabled;
+        return this.enabled;
+    }
+
+    play(freq = 440, duration = 0.1) {
+        if (!this.enabled) return;
+        if (!this.ctx) {
+            this.ctx = new (window.AudioContext || window.webkitAudioContext)();
+        }
+        const osc = this.ctx.createOscillator();
+        const gain = this.ctx.createGain();
+        osc.frequency.value = freq;
+        osc.connect(gain);
+        gain.connect(this.ctx.destination);
+        osc.start();
+        osc.stop(this.ctx.currentTime + duration);
+    }
+
+    drop() {
+        this.play(300, 0.05);
+    }
+
+    clear() {
+        this.play(600, 0.1);
+    }
+}

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1,0 +1,50 @@
+export const TETROMINOES = {
+    I: [
+        [1, 1, 1, 1]
+    ],
+    J: [
+        [1, 0, 0],
+        [1, 1, 1]
+    ],
+    L: [
+        [0, 0, 1],
+        [1, 1, 1]
+    ],
+    O: [
+        [1, 1],
+        [1, 1]
+    ],
+    S: [
+        [0, 1, 1],
+        [1, 1, 0]
+    ],
+    T: [
+        [0, 1, 0],
+        [1, 1, 1]
+    ],
+    Z: [
+        [1, 1, 0],
+        [0, 1, 1]
+    ]
+};
+
+const COLORS = ['#ff7675','#74b9ff','#55efc4','#ffeaa7','#a29bfe','#fd79a8','#fab1a0'];
+
+export class Block {
+    constructor(shape, color) {
+        this.shape = shape;
+        this.color = color;
+    }
+
+    rotate() {
+        this.shape = this.shape[0].map((_, i) => this.shape.map(row => row[i]).reverse());
+    }
+}
+
+export function randomBlock() {
+    const keys = Object.keys(TETROMINOES);
+    const key = keys[Math.floor(Math.random() * keys.length)];
+    const shape = TETROMINOES[key].map(row => [...row]);
+    const color = COLORS[Math.floor(Math.random() * COLORS.length)];
+    return new Block(shape, color);
+}

--- a/js/game.js
+++ b/js/game.js
@@ -1,0 +1,196 @@
+import { Grid } from './grid.js';
+import { Block, randomBlock } from './blocks.js';
+import { Score } from './score.js';
+import { Sound } from './audio.js';
+import { saveState, loadState, clearState } from './storage.js';
+
+class Game {
+    constructor() {
+        this.grid = new Grid(20, 10, '.grid-container');
+        this.score = new Score('.score', '.high-score');
+        this.current = null;
+        this.next = randomBlock();
+        this.currentRow = 0;
+        this.currentCol = 0;
+        this.interval = 800;
+        this.timer = null;
+        this.nextEl = document.querySelector('.next-block');
+        this.pauseBtn = document.querySelector('.btn-pause');
+        this.soundBtn = document.querySelector('.btn-sound');
+        this.sound = new Sound();
+        this.paused = false;
+    }
+
+    init() {
+        this.loadGame();
+        document.addEventListener('keydown', e => this.handleKey(e));
+        document.querySelector('.btn-restart').addEventListener('click', () => this.restart());
+        this.pauseBtn.addEventListener('click', () => this.togglePause());
+        this.soundBtn.addEventListener('click', () => this.toggleSound());
+        window.addEventListener('beforeunload', () => this.saveGame());
+        this.start();
+    }
+
+    start() {
+        this.stop();
+        this.timer = setInterval(() => this.tick(), this.interval);
+    }
+
+    stop() {
+        if (this.timer) clearInterval(this.timer);
+    }
+
+    spawn() {
+        this.current = this.next;
+        this.currentRow = 0;
+        this.currentCol = Math.floor(this.grid.cols / 2) - Math.ceil(this.current.shape[0].length / 2);
+        this.next = randomBlock();
+        this.renderNext();
+        if (!this.grid.isValid(this.current, this.currentRow, this.currentCol)) {
+            alert('Game Over!');
+            this.restart();
+        }
+        this.grid.render({ block: this.current, row: this.currentRow, col: this.currentCol });
+        this.saveGame();
+    }
+
+    renderNext() {
+        this.nextEl.innerHTML = '';
+        const rows = this.next.shape.length;
+        const cols = this.next.shape[0].length;
+        const el = document.createElement('div');
+        el.classList.add('block');
+        el.style.gridTemplateColumns = `repeat(${cols}, 30px)`;
+        for (let r = 0; r < rows; r++) {
+            for (let c = 0; c < cols; c++) {
+                if (!this.next.shape[r][c]) {
+                    const spacer = document.createElement('div');
+                    spacer.style.width = '30px';
+                    spacer.style.height = '30px';
+                    el.appendChild(spacer);
+                } else {
+                    const cell = document.createElement('div');
+                    cell.classList.add('block-cell');
+                    cell.style.background = this.next.color;
+                    el.appendChild(cell);
+                }
+            }
+        }
+        this.nextEl.appendChild(el);
+    }
+
+    tick() {
+        if (this.grid.isValid(this.current, this.currentRow + 1, this.currentCol)) {
+            this.currentRow++;
+        } else {
+            this.grid.place(this.current, this.currentRow, this.currentCol);
+            this.sound.drop();
+            const cleared = this.grid.clearLines();
+            if (cleared) {
+                this.score.add(cleared * 100);
+                this.sound.clear();
+            }
+            this.spawn();
+        }
+        this.grid.render({ block: this.current, row: this.currentRow, col: this.currentCol });
+        this.saveGame();
+    }
+
+    handleKey(e) {
+        switch (e.key) {
+            case 'ArrowLeft':
+                if (this.grid.isValid(this.current, this.currentRow, this.currentCol - 1)) {
+                    this.currentCol--;
+                }
+                break;
+            case 'ArrowRight':
+                if (this.grid.isValid(this.current, this.currentRow, this.currentCol + 1)) {
+                    this.currentCol++;
+                }
+                break;
+            case 'ArrowDown':
+                if (this.grid.isValid(this.current, this.currentRow + 1, this.currentCol)) {
+                    this.currentRow++;
+                }
+                break;
+            case 'ArrowUp':
+                const original = this.current.shape.map(row => [...row]);
+                this.current.rotate();
+                if (!this.grid.isValid(this.current, this.currentRow, this.currentCol)) {
+                    this.current.shape = original;
+                }
+                break;
+            case ' ': // hard drop
+                while (this.grid.isValid(this.current, this.currentRow + 1, this.currentCol)) {
+                    this.currentRow++;
+                }
+                this.tick();
+                break;
+            case 'p':
+            case 'P':
+                this.togglePause();
+                return;
+        }
+        this.grid.render({ block: this.current, row: this.currentRow, col: this.currentCol });
+        this.saveGame();
+    }
+
+    restart() {
+        this.stop();
+        this.grid = new Grid(20, 10, '.grid-container');
+        this.score.reset();
+        this.next = randomBlock();
+        clearState();
+        this.spawn();
+        this.start();
+    }
+
+    togglePause() {
+        if (this.paused) {
+            this.start();
+            this.pauseBtn.textContent = 'Pause';
+        } else {
+            this.stop();
+            this.pauseBtn.textContent = 'Resume';
+        }
+        this.paused = !this.paused;
+    }
+
+    toggleSound() {
+        const enabled = this.sound.toggle();
+        this.soundBtn.textContent = enabled ? '🔊' : '🔇';
+    }
+
+    saveGame() {
+        saveState({
+            grid: this.grid.cells,
+            score: this.score.score,
+            current: { shape: this.current.shape, color: this.current.color },
+            next: { shape: this.next.shape, color: this.next.color },
+            currentRow: this.currentRow,
+            currentCol: this.currentCol
+        });
+    }
+
+    loadGame() {
+        const saved = loadState();
+        if (saved) {
+            this.grid.cells = saved.grid;
+            this.current = new Block(saved.current.shape, saved.current.color);
+            this.next = new Block(saved.next.shape, saved.next.color);
+            this.currentRow = saved.currentRow;
+            this.currentCol = saved.currentCol;
+            this.score.reset();
+            this.score.add(saved.score);
+            this.renderNext();
+            this.grid.render({ block: this.current, row: this.currentRow, col: this.currentCol });
+        } else {
+            this.spawn();
+        }
+    }
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+    const game = new Game();
+    game.init();
+});

--- a/js/grid.js
+++ b/js/grid.js
@@ -1,0 +1,74 @@
+export class Grid {
+    constructor(rows, cols, containerSelector) {
+        this.rows = rows;
+        this.cols = cols;
+        this.container = document.querySelector(containerSelector);
+        this.cells = Array.from({ length: rows }, () => Array(cols).fill(null));
+        this.render();
+    }
+
+    render(active = null) {
+        this.container.innerHTML = '';
+        for (let r = 0; r < this.rows; r++) {
+            for (let c = 0; c < this.cols; c++) {
+                const cell = document.createElement('div');
+                cell.classList.add('grid-cell');
+                let color = this.cells[r][c];
+                if (active) {
+                    const { block, row, col } = active;
+                    if (
+                        r >= row &&
+                        r < row + block.shape.length &&
+                        c >= col &&
+                        c < col + block.shape[0].length &&
+                        block.shape[r - row][c - col]
+                    ) {
+                        color = block.color;
+                    }
+                }
+                if (color) cell.style.background = color;
+                this.container.appendChild(cell);
+            }
+        }
+    }
+
+    isValid(block, row, col) {
+        for (let r = 0; r < block.shape.length; r++) {
+            for (let c = 0; c < block.shape[r].length; c++) {
+                if (!block.shape[r][c]) continue;
+                const newRow = row + r;
+                const newCol = col + c;
+                if (
+                    newRow < 0 || newRow >= this.rows ||
+                    newCol < 0 || newCol >= this.cols ||
+                    this.cells[newRow][newCol]
+                ) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    place(block, row, col) {
+        for (let r = 0; r < block.shape.length; r++) {
+            for (let c = 0; c < block.shape[r].length; c++) {
+                if (!block.shape[r][c]) continue;
+                this.cells[row + r][col + c] = block.color;
+            }
+        }
+    }
+
+    clearLines() {
+        let cleared = 0;
+        for (let r = this.rows - 1; r >= 0; r--) {
+            if (this.cells[r].every(cell => cell)) {
+                this.cells.splice(r, 1);
+                this.cells.unshift(Array(this.cols).fill(null));
+                cleared++;
+                r++;
+            }
+        }
+        return cleared;
+    }
+}

--- a/js/score.js
+++ b/js/score.js
@@ -1,0 +1,30 @@
+export class Score {
+    constructor(scoreSelector, highScoreSelector) {
+        this.scoreEl = document.querySelector(scoreSelector);
+        this.highScoreEl = document.querySelector(highScoreSelector);
+        this.score = 0;
+        this.highScore = 0;
+        this.loadHighScore();
+    }
+
+    add(points) {
+        this.score += points;
+        this.scoreEl.textContent = this.score;
+        if (this.score > this.highScore) {
+            this.highScore = this.score;
+            this.highScoreEl.textContent = `Best: ${this.highScore}`;
+            localStorage.setItem('highScore', this.highScore);
+        }
+    }
+
+    reset() {
+        this.score = 0;
+        this.scoreEl.textContent = this.score;
+    }
+
+    loadHighScore() {
+        const saved = parseInt(localStorage.getItem('highScore')) || 0;
+        this.highScore = saved;
+        this.highScoreEl.textContent = `Best: ${this.highScore}`;
+    }
+}

--- a/js/storage.js
+++ b/js/storage.js
@@ -1,0 +1,12 @@
+export function saveState(state) {
+    localStorage.setItem('gameState', JSON.stringify(state));
+}
+
+export function loadState() {
+    const raw = localStorage.getItem('gameState');
+    return raw ? JSON.parse(raw) : null;
+}
+
+export function clearState() {
+    localStorage.removeItem('gameState');
+}


### PR DESCRIPTION
## Summary
- Add pause and sound controls to interface with matching styles
- Implement Sound class with drop/clear effects and toggle button
- Auto-save and restore game state via localStorage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890ca37b5c4832e835ba562fd55189d